### PR TITLE
Added a `LocalCtx` struct for thread-local state

### DIFF
--- a/src/tools/bsan/bsan-rt/src/local.rs
+++ b/src/tools/bsan/bsan-rt/src/local.rs
@@ -1,0 +1,42 @@
+use core::mem::{self, MaybeUninit};
+
+use crate::*;
+
+#[derive(Debug)]
+pub struct LocalCtx {
+    thread_id: ThreadId,
+}
+impl LocalCtx {
+    pub fn new(ctx: &GlobalCtx) -> Self {
+        let thread_id = ctx.new_thread_id();
+        Self { thread_id }
+    }
+}
+
+#[thread_local]
+pub static LOCAL_CTX: UnsafeCell<MaybeUninit<LocalCtx>> = UnsafeCell::new(MaybeUninit::uninit());
+
+/// Initializes the local context object.
+/// This function should only be called once, when a thread is initialized.
+#[inline]
+pub unsafe fn init_local_ctx(ctx: &GlobalCtx) -> *mut LocalCtx {
+    (*LOCAL_CTX.get()).write(LocalCtx::new(ctx));
+    local_ctx()
+}
+
+/// Deinitializes the local context object.
+/// This function must only be called once: when a thread is terminating.
+/// It is marked as `unsafe`, since multiple other API functions rely
+/// on the assumption that the current thread remains initialized.
+#[inline]
+pub unsafe fn deinit_local_ctx() {
+    drop(ptr::replace(LOCAL_CTX.get(), MaybeUninit::uninit()).assume_init());
+}
+
+/// Accessing the local context is unsafe, since the user needs to ensure that
+/// the context is initialized.
+#[inline]
+pub unsafe fn local_ctx() -> *mut LocalCtx {
+    let ctx: *mut MaybeUninit<LocalCtx> = LOCAL_CTX.get();
+    mem::transmute(ctx)
+}


### PR DESCRIPTION
In addition to our `GlobalCtx`, we'll need a `LocalCtx` to hold the shadow stack and any other thread-local items. Each `LocalCtx` holds a `ThreadId`, which is another `usize` wrapper. 

The `LocalCtx` is initialized in the same way as the `GlobalCtx`—I've changed it up a bit to use `MaybeUninit<T>` instead of `Option`, since we're already just bypassing the checks for `None` anyway. 

I have also removed `debug_assert` expressions in anticipation of [1.86.0](https://blog.rust-lang.org/2025/04/03/Rust-1.86.0.html), which automatically adds these checks in debug mode.


