### PR TITLE
Added `BlockAllocator<T>` a semi-lock-free bump allocator for `T`

### DIFF
--- a/src/tools/bsan/bsan-rt/src/block.rs
+++ b/src/tools/bsan/bsan-rt/src/block.rs
@@ -38,9 +38,7 @@ impl<T> Drop for Block<T> {
         // SAFETY: our munmap pointer will be valid by construction of the GlobalCtx.
         // We can safely transmute it to c_void since that's what it was originally when
         // it was allocated by mmap
-        let success = unsafe {
-            (self.munmap)(mem::transmute(self.base.as_ptr()), self.size.get())
-        };
+        let success = unsafe { (self.munmap)(mem::transmute(self.base.as_ptr()), self.size.get()) };
         if success != 0 {
             panic!("Failed to unmap block!");
         }
@@ -138,10 +136,12 @@ impl<T: Linkable<T>> BlockAllocator<T> {
 
 #[cfg(test)]
 mod test {
-    use std::{sync::Arc, thread};
+    use std::sync::Arc;
+    use std::thread;
+
+    use super::*;
     use crate::global::test::TEST_HOOKS;
     use crate::*;
-    use super::*;
     struct Link {
         link: UnsafeCell<*mut u8>,
     }

--- a/src/tools/bsan/bsan-rt/src/block.rs
+++ b/src/tools/bsan/bsan-rt/src/block.rs
@@ -98,7 +98,7 @@ impl<T: Linkable<T>> BlockAllocator<T> {
             }
         };
         self.cursor
-            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |val| {
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |val| {
                 if val.is_null() {
                     // We have reached the end of the block
                     None

--- a/src/tools/bsan/bsan-rt/src/block.rs
+++ b/src/tools/bsan/bsan-rt/src/block.rs
@@ -1,0 +1,204 @@
+use core::cell::UnsafeCell;
+use core::hint;
+use core::mem::MaybeUninit;
+use core::num::NonZeroUsize;
+use core::ptr::NonNull;
+use core::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
+
+use crate::*;
+
+/// Types that implement this trait can act as elements
+/// of a singly-linked list. For this implementation to be sound,
+/// the pointer that is returned must not be mutated concurrently.
+pub unsafe trait Linkable<T: Sized> {
+    fn next(&self) -> *mut *mut T;
+}
+
+/// An mmap-ed chunk of memory that will munmap the chunk on drop.
+#[derive(Debug)]
+pub struct Block<T: Sized> {
+    pub size: NonZeroUsize,
+    pub base: NonNull<T>,
+    pub munmap: MUnmap,
+}
+
+impl<T: Sized> Block<T> {
+    /// The last valid, addressable location within the block (at its high-end)
+    fn last(&self) -> *mut T {
+        unsafe { self.base.as_ptr().add(self.size.get() - 1) }
+    }
+    /// The first valid, addressable location within the block (at its low-end)
+    fn first(&self) -> *mut T {
+        self.base.as_ptr()
+    }
+}
+
+impl<T> Drop for Block<T> {
+    fn drop(&mut self) {
+        // SAFETY: our munmap pointer will be valid by construction of the GlobalCtx.
+        // We can safely transmute it to c_void since that's what it was originally when
+        // it was allocated by mmap
+        let success = unsafe {
+            (self.munmap)(mem::transmute(self.base.as_ptr()), self.size.get())
+        };
+        if success != 0 {
+            panic!("Failed to unmap block!");
+        }
+    }
+}
+
+/// A fixed-capacity, semi-lock-free, thread-safe bump-allocator.
+#[derive(Debug)]
+pub struct BlockAllocator<T: Linkable<T>> {
+    /// The next valid element, which will be uninitialized.
+    cursor: AtomicPtr<MaybeUninit<T>>,
+    /// A list of freed elements, which can be anywhere in the block.
+    /// This needs to be interior mutable since both alloc and dealloc
+    /// need to modify the free list through &self
+    free_list: UnsafeCell<*mut T>,
+    /// A mutex for the free list
+    free_lock: AtomicBool,
+    /// The block of memory where instances are allocated from.
+    block: Block<T>,
+}
+
+// SAFETY: Whenever we mutate the allocator, we either lock on `free_lock`
+// or we're executing an atomic operation.
+unsafe impl<T: Linkable<T>> Send for BlockAllocator<T> {}
+unsafe impl<T: Linkable<T>> Sync for BlockAllocator<T> {}
+
+impl<T: Linkable<T>> BlockAllocator<T> {
+    /// Initializes a BlockAllocator for the given block.
+    fn new(block: Block<T>) -> Self {
+        BlockAllocator {
+            // we begin at the high-end of the block and decrement downward
+            cursor: AtomicPtr::new(block.last() as *mut MaybeUninit<T>),
+            free_list: UnsafeCell::new(core::ptr::null::<T>() as *mut T),
+            free_lock: AtomicBool::new(false),
+            block,
+        }
+    }
+
+    /// Allocates a new instance from the block.
+    /// If a prior allocation has been freed, it will be reused instead of
+    /// incrementing the internal cursor.
+    fn alloc(&self) -> Option<NonNull<MaybeUninit<T>>> {
+        if !self.free_lock.swap(true, Ordering::Acquire) {
+            let curr = unsafe { *self.free_list.get() };
+            let curr = if !curr.is_null() {
+                unsafe {
+                    let next = (*curr).next();
+                    *self.free_list.get() = *next;
+                    Some(NonNull::new_unchecked(curr as *mut MaybeUninit<T>))
+                }
+            } else {
+                None
+            };
+            self.free_lock.store(false, Ordering::Release);
+            if curr.is_some() {
+                return curr;
+            }
+        };
+        self.cursor
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |val| {
+                if val.is_null() {
+                    // We have reached the end of the block
+                    None
+                } else if val.addr() == self.block.first().addr() {
+                    // We are handing out the last element of the block
+                    Some(core::ptr::null_mut())
+                } else {
+                    // There's more than one element remaining in the block
+                    unsafe { Some(val.sub(1)) }
+                }
+            })
+            .map(NonNull::new)
+            .ok()?
+    }
+
+    /// Deallocates a pointer that has been allocated from the block.
+    /// Passing a pointer to a different block will result in undefined behavior,
+    /// since "freed" allocations are added to a list and reused for subsequent
+    /// calls to alloc. The allocation does not need to be initialized; you can pass
+    /// the result of `BlockAllocator::alloc` directly to this function.
+    unsafe fn dealloc(&self, ptr: NonNull<MaybeUninit<T>>) {
+        while self.free_lock.swap(true, Ordering::Acquire) {
+            hint::spin_loop();
+        }
+        let curr = self.free_list.get();
+        unsafe {
+            let ptr = (*ptr.as_ptr()).as_mut_ptr();
+            let ptr_next = (*ptr).next();
+            *ptr_next = *curr;
+            *self.free_list.get() = ptr;
+        }
+        self.free_lock.store(false, Ordering::Release);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{sync::Arc, thread};
+    use crate::global::test::TEST_HOOKS;
+    use crate::*;
+    use super::*;
+    struct Link {
+        link: UnsafeCell<*mut u8>,
+    }
+
+    unsafe impl Linkable<Link> for Link {
+        fn next(&self) -> *mut *mut Link {
+            unsafe { mem::transmute(self.link.get()) }
+        }
+    }
+
+    #[test]
+    fn allocate_from_page_in_parallel() {
+        let ctx = unsafe { init_global_ctx(TEST_HOOKS.clone()) };
+        let ctx = unsafe { &*ctx };
+        let block = ctx.new_block::<Link>(unsafe { NonZero::new_unchecked(200) });
+        let page = Arc::new(BlockAllocator::<Link>::new(block));
+        let mut threads = Vec::new();
+
+        for id in 0..10 {
+            let page = page.clone();
+            // Create 10 threads, which will each allocate and deallocate from the page
+            threads.push(thread::spawn(move || {
+                // Allocate 10 elements per thread.
+                let mut allocs: Vec<_> = (0..10).map(|_| page.alloc().unwrap()).collect();
+                if id % 2 == 0 {
+                    // Even-numbered threads will immediately free the elements, adding them to the
+                    // free list for odd-numbered threads to pick up.
+                    for alloc in allocs.drain(..) {
+                        unsafe {
+                            page.dealloc(alloc);
+                        }
+                    }
+                } else {
+                    // Odd-numbered threads will continue to allocate elements,
+                    // hopefully picking the allocations freed by even-numbered threads.
+                    for _ in 0..10 {
+                        if let Some(alloc) = page.alloc() {
+                            unsafe {
+                                (*alloc.as_ptr())
+                                    .write(Link { link: UnsafeCell::new(core::ptr::null_mut()) });
+                            }
+                            allocs.push(alloc);
+                        }
+                        allocs.push(page.alloc().unwrap());
+                    }
+                    allocs.drain(..).for_each(|alloc| unsafe {
+                        page.dealloc(alloc);
+                    });
+                }
+            }));
+        }
+        for thread in threads {
+            thread.join().unwrap();
+        }
+
+        unsafe {
+            deinit_global_ctx();
+        }
+    }
+}

--- a/src/tools/bsan/bsan-rt/src/global.rs
+++ b/src/tools/bsan/bsan-rt/src/global.rs
@@ -79,12 +79,12 @@ impl GlobalCtx {
     }
 
     pub fn new_thread_id(&self) -> ThreadId {
-        let id = self.next_thread_id.fetch_add(1, core::sync::atomic::Ordering::SeqCst);
+        let id = self.next_thread_id.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
         ThreadId::new(id)
     }
 
     pub fn new_alloc_id(&self) -> AllocId {
-        let id = self.next_alloc_id.fetch_add(1, core::sync::atomic::Ordering::SeqCst);
+        let id = self.next_alloc_id.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
         AllocId::new(id)
     }
     /// Prints a given set of formatted arguments. This function is not meant

--- a/src/tools/bsan/bsan-rt/src/global.rs
+++ b/src/tools/bsan/bsan-rt/src/global.rs
@@ -1,14 +1,18 @@
+#![feature(allocator_api)]
+#![feature(unsafe_cell_access)]
 use alloc::collections::VecDeque;
 use alloc::vec::Vec;
-use core::cell::SyncUnsafeCell;
+use core::cell::{SyncUnsafeCell, UnsafeCell};
 use core::ffi::CStr;
 use core::fmt;
 use core::fmt::{Write, write};
-use core::mem::{self, zeroed};
+use core::mem::{self, MaybeUninit, zeroed};
+use core::num::NonZeroUsize;
 use core::ops::{Deref, DerefMut};
 use core::ptr::NonNull;
-use core::sync::atomic::AtomicUsize;
+use core::sync::atomic::{AtomicBool, AtomicPtr, AtomicUsize, Ordering};
 
+use block::*;
 use hashbrown::{DefaultHashBuilder, HashMap};
 use rustc_hash::FxBuildHasher;
 
@@ -30,6 +34,9 @@ pub struct GlobalCtx {
     next_thread_id: AtomicUsize,
 }
 
+const BSAN_MMAP_PROT: i32 = libc::PROT_READ | libc::PROT_WRITE;
+const BSAN_MMAP_FLAGS: i32 = libc::MAP_ANONYMOUS | libc::MAP_PRIVATE;
+
 impl GlobalCtx {
     /// Creates a new instance of `GlobalCtx` using the given `BsanHooks`.
     /// This function will also initialize our shadow heap
@@ -41,7 +48,29 @@ impl GlobalCtx {
         }
     }
 
-    fn alloc(&self) -> BsanAllocHooks {
+    pub fn new_block<T>(&self, num_elements: NonZeroUsize) -> Block<T> {
+        let layout = Layout::array::<T>(num_elements.into()).unwrap();
+        let size = NonZeroUsize::new(layout.size()).unwrap();
+        let base = unsafe {
+            (self.hooks.mmap)(
+                ptr::null_mut(),
+                layout.size(),
+                BSAN_MMAP_PROT,
+                BSAN_MMAP_FLAGS,
+                -1,
+                0,
+            )
+        };
+
+        if base.is_null() {
+            panic!("Allocation failed");
+        }
+        let base = unsafe { NonNull::new_unchecked(mem::transmute(base)) };
+        let munmap = self.hooks.munmap;
+        Block { size, base, munmap }
+    }
+
+    fn allocator(&self) -> BsanAllocHooks {
         self.hooks.alloc
     }
 
@@ -127,7 +156,7 @@ impl<T> DerefMut for BVec<T> {
 
 impl<T> BVec<T> {
     fn new(ctx: &GlobalCtx) -> Self {
-        unsafe { Self(Vec::new_in(ctx.alloc())) }
+        unsafe { Self(Vec::new_in(ctx.allocator())) }
     }
 }
 
@@ -166,7 +195,7 @@ impl<T> DerefMut for BVecDeque<T> {
 
 impl<T> BVecDeque<T> {
     fn new(ctx: &GlobalCtx) -> Self {
-        unsafe { Self(VecDeque::new_in(ctx.alloc())) }
+        unsafe { Self(VecDeque::new_in(ctx.allocator())) }
     }
 }
 
@@ -193,7 +222,7 @@ impl<K, V> DerefMut for BHashMap<K, V> {
 
 impl<K, V> BHashMap<K, V> {
     fn new(ctx: &GlobalCtx) -> Self {
-        unsafe { Self(HashMap::with_hasher_in(FxBuildHasher, ctx.alloc())) }
+        unsafe { Self(HashMap::with_hasher_in(FxBuildHasher, ctx.allocator())) }
     }
 }
 
@@ -220,15 +249,16 @@ mod global_alloc {
     static GLOBAL_ALLOCATOR: DummyAllocator = DummyAllocator;
 }
 
-pub static GLOBAL_CTX: SyncUnsafeCell<Option<GlobalCtx>> = SyncUnsafeCell::new(None);
+pub static GLOBAL_CTX: SyncUnsafeCell<MaybeUninit<GlobalCtx>> =
+    SyncUnsafeCell::new(MaybeUninit::uninit());
 
 /// Initializes the global context object.
 /// This function must only be called once: when the program is first initialized.
 /// It is marked as `unsafe`, because it relies on the set of function pointers in
 /// `BsanHooks` to be valid.
 #[inline]
-pub unsafe fn init_global_ctx(hooks: BsanHooks) -> &'static GlobalCtx {
-    *GLOBAL_CTX.get() = Some(GlobalCtx::new(hooks));
+pub unsafe fn init_global_ctx(hooks: BsanHooks) -> *mut GlobalCtx {
+    (*GLOBAL_CTX.get()).write(GlobalCtx::new(hooks));
     global_ctx()
 }
 
@@ -238,19 +268,20 @@ pub unsafe fn init_global_ctx(hooks: BsanHooks) -> &'static GlobalCtx {
 /// on the assumption that this function has not been called yet.
 #[inline]
 pub unsafe fn deinit_global_ctx() {
-    drop((&mut *GLOBAL_CTX.get()).take());
+    drop(ptr::replace(GLOBAL_CTX.get(), MaybeUninit::uninit()).assume_init());
 }
 
 /// Accessing the global context is unsafe since the user needs to ensure that
 /// the context is initialized, e.g. `bsan_init` has been called and `bsan_deinit`
 /// has not yet been called.
 #[inline]
-pub unsafe fn global_ctx() -> &'static GlobalCtx {
-    (&(*GLOBAL_CTX.get())).as_ref().unwrap_unchecked()
+pub unsafe fn global_ctx() -> *mut GlobalCtx {
+    let ctx: *mut MaybeUninit<GlobalCtx> = GLOBAL_CTX.get();
+    mem::transmute(ctx)
 }
 
 #[cfg(test)]
-mod test {
+pub mod test {
     use crate::*;
 
     unsafe extern "C" fn test_print(ptr: *const c_char) {

--- a/src/tools/bsan/bsan-rt/src/lib.rs
+++ b/src/tools/bsan/bsan-rt/src/lib.rs
@@ -25,6 +25,7 @@ mod local;
 pub use local::*;
 
 mod shadow;
+mod block;
 
 pub type MMap = unsafe extern "C" fn(*mut c_void, usize, i32, i32, i32, c_ulonglong) -> *mut c_void;
 pub type MUnmap = unsafe extern "C" fn(*mut c_void, usize) -> i32;

--- a/src/tools/bsan/bsan-rt/src/lib.rs
+++ b/src/tools/bsan/bsan-rt/src/lib.rs
@@ -24,8 +24,8 @@ pub use global::*;
 mod local;
 pub use local::*;
 
-mod shadow;
 mod block;
+mod shadow;
 
 pub type MMap = unsafe extern "C" fn(*mut c_void, usize, i32, i32, i32, c_ulonglong) -> *mut c_void;
 pub type MUnmap = unsafe extern "C" fn(*mut c_void, usize) -> i32;


### PR DESCRIPTION
There will be several use cases for allocating a series of small heap objects. We can make this more efficient by mapping a page of *N* objects and then handing out pointers to that page.

* `Block<T>` - Represents unique ownership over a heap-allocated array of `T` created by calling `mmap`. The page will be unmapped when the object is dropped.

* `Linkable<T>` - Objects that implement this trait can act as nodes of a singly linked list.

* `BlockAllocator<T>` - A bump allocator based on a `Block<T>`, where `T:Linkable<T>`. Deallocating an object adds it to a list of freed objects. As long as the the free list is empty, allocating new objects is lock-free.

The unit test for this implementation creates 10 threads and interleaves allocation, deallocation, and mutation in search of race conditions. I've run this through Miri (out-of-tree) several times without error. 