### PR TITLE
Added Clippy linting for runtime components

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
       - name: Switch to nightly
         run: |
-          rustup default ${{ env.BSAN_TOOLCHAIN }}
+          rustup default ${{ vars.BSAN_TOOLCHAIN }}
           rustup component add rust-src rustc-dev llvm-tools-preview clippy
       - name: Upstream
         run: src/ci/scripts/setup-upstream-remote.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
       - name: Switch to nightly
         run: |
-          rustup default $BSAN_TOOLCHAIN
+          rustup default "$BSAN_TOOLCHAIN"
           rustup component add rust-src rustc-dev llvm-tools-preview clippy
       - name: Upstream
         run: src/ci/scripts/setup-upstream-remote.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
       - name: Switch to nightly
         run: |
-          rustup default nightly-2024-11-21
+          rustup default $BSAN_TOOLCHAIN
           rustup component add rust-src rustc-dev llvm-tools-preview clippy
       - name: Upstream
         run: src/ci/scripts/setup-upstream-remote.sh
@@ -100,3 +100,4 @@ jobs:
         run: ./x.py test --stage 1 src/tools/bsan/bsan-rt
       - name: UI Tests
         run: ./x.py test --stage 2 src/tools/bsan/bsan-driver
+      

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,18 @@ jobs:
         run: src/ci/scripts/setup-upstream-remote.sh
       - name: Format
         run: ./x.py fmt --check
+      - name: Clippy (bsan-rt)
+        run: |
+          cd src/tools/bsan/bsan-rt
+          cargo clippy --all-targets --all-features -- -D warnings
+      - name: Clippy (bsan-driver)
+        run: |
+          cd src/tools/bsan/bsan-driver
+          cargo clippy --all-targets --all-features -- -D warnings
+      - name: Clippy (cargo-bsan)
+        run: |
+          cd src/tools/bsan/bsan-driver/cargo-bsan
+          cargo clippy --all-targets --all-features -- -D warnings
   build:
     needs: [fmt]
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: Switch to nightly
-        run: rustup override set nightly
+        run: |
+          rustup default nightly-2024-11-21
+          rustup component add rust-src rustc-dev llvm-tools-preview clippy
       - name: Upstream
         run: src/ci/scripts/setup-upstream-remote.sh
       - name: Format
@@ -33,7 +35,7 @@ jobs:
       - name: Clippy (bsan-rt)
         run: |
           cd src/tools/bsan/bsan-rt
-          cargo clippy --all-targets --all-features -- -D warnings
+          RUSTFLAGS='-C panic=abort -Zpanic_abort_tests' cargo clippy --all-targets --all-features -- -D warnings
       - name: Clippy (bsan-driver)
         run: |
           cd src/tools/bsan/bsan-driver

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
       - name: Switch to nightly
         run: |
-          rustup default "$BSAN_TOOLCHAIN"
+          rustup default ${{ env.BSAN_TOOLCHAIN }}
           rustup component add rust-src rustc-dev llvm-tools-preview clippy
       - name: Upstream
         run: src/ci/scripts/setup-upstream-remote.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Switch to nightly
+        run: rustup override set nightly
       - name: Upstream
         run: src/ci/scripts/setup-upstream-remote.sh
       - name: Format

--- a/src/tools/bsan/bsan-driver/cargo-bsan/src/phases.rs
+++ b/src/tools/bsan/bsan-driver/cargo-bsan/src/phases.rs
@@ -52,7 +52,7 @@ pub fn phase_cargo_bsan(mut args: impl Iterator<Item = String>) {
         return;
     }
 
-    setup(&subcommand, &rustc_version.host.as_str(), &rustc_version, verbose, quiet);
+    setup(&subcommand, rustc_version.host.as_str(), &rustc_version, verbose, quiet);
 
     let bsan_sysroot = get_target_sysroot_dir();
     let bsan_path = find_bsan();

--- a/src/tools/bsan/bsan-driver/cargo-bsan/src/setup.rs
+++ b/src/tools/bsan/bsan-driver/cargo-bsan/src/setup.rs
@@ -160,7 +160,7 @@ pub fn setup(
             } else {
                 // Keep all output on a single line.
                 eprint!("... ");
-                after_build_output = format!("done\n");
+                after_build_output = "done\n".to_string();
             }
         }
     };

--- a/src/tools/bsan/bsan-driver/cargo-bsan/src/util.rs
+++ b/src/tools/bsan/bsan-driver/cargo-bsan/src/util.rs
@@ -102,7 +102,7 @@ pub fn exec_stdout(mut cmd: Command) -> String {
     if output.status.success() {
         String::from_utf8(output.stdout).expect("output bytes should be valid utf8")
     } else {
-        panic!("failed to run command: {:?}", output)
+        panic!("failed to run command: {output:?}")
     }
 }
 

--- a/src/tools/bsan/bsan-driver/src/bin/bsan-driver.rs
+++ b/src/tools/bsan/bsan-driver/src/bin/bsan-driver.rs
@@ -27,7 +27,7 @@ fn main() {
         // to be instrumented, while "host" indicates that it is a build script or procedural
         // macro, which we can skip.
 
-        if let Some(crate_kind) = env::var("BSAN_BE_RUSTC").ok() {
+        if let Ok(crate_kind) = env::var("BSAN_BE_RUSTC") {
             let is_target = match crate_kind.as_str() {
                 "host" => false,
                 "target" => true,

--- a/src/tools/bsan/bsan-driver/src/lib.rs
+++ b/src/tools/bsan/bsan-driver/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(rustc_private)]
-#![warn(clippy::pedantic)]
 
 extern crate rustc_driver;
 

--- a/src/tools/bsan/bsan-driver/src/lib.rs
+++ b/src/tools/bsan/bsan-driver/src/lib.rs
@@ -26,7 +26,7 @@ pub fn run_compiler(
             BSAN_DEFAULT_ARGS.iter().map(ToString::to_string).collect::<Vec<_>>();
         if let Some(runtime) = env::var_os("BSAN_RT_SYSROOT") {
             let rt = runtime.to_string_lossy();
-            additional_args.push(format!("-L{}/lib", rt));
+            additional_args.push(format!("-L{rt}/lib"));
         }
         args.splice(1..1, additional_args);
     }

--- a/src/tools/bsan/bsan-rt/build.rs
+++ b/src/tools/bsan/bsan-rt/build.rs
@@ -9,5 +9,5 @@ fn main() {
         .with_crate(crate_dir.clone())
         .generate()
         .expect("Unable to generate bindings")
-        .write_to_file(Path::new(&out_dir).join(format!("bsan_rt.h")));
+        .write_to_file(Path::new(&out_dir).join("bsan_rt.h"));
 }

--- a/src/tools/bsan/bsan-rt/src/error.rs
+++ b/src/tools/bsan/bsan-rt/src/error.rs
@@ -1,0 +1,16 @@
+use core::fmt::Display;
+
+pub type Result<T> = core::result::Result<T, BsanError>;
+
+#[derive(Debug, Clone)]
+pub enum BsanError {
+    ShadowStackOverflow,
+}
+
+impl Display for BsanError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            BsanError::ShadowStackOverflow => write!(f, "Shadow stack overflow"),
+        }
+    }
+}

--- a/src/tools/bsan/bsan-rt/src/lib.rs
+++ b/src/tools/bsan/bsan-rt/src/lib.rs
@@ -67,7 +67,8 @@ unsafe impl Allocator for BsanAllocHooks {
     }
 
     unsafe fn deallocate(&self, ptr: NonNull<u8>, _layout: Layout) {
-        (self.free)(mem::transmute(ptr.as_ptr()))
+        let ptr = mem::transmute::<*mut u8, *mut libc::c_void>(ptr.as_ptr());
+        (self.free)(ptr);
     }
 }
 

--- a/src/tools/bsan/bsan-rt/src/local.rs
+++ b/src/tools/bsan/bsan-rt/src/local.rs
@@ -17,6 +17,9 @@ impl LocalCtx {
 pub static LOCAL_CTX: UnsafeCell<MaybeUninit<LocalCtx>> = UnsafeCell::new(MaybeUninit::uninit());
 
 /// Initializes the local context object.
+///
+/// # Safety
+///
 /// This function should only be called once, when a thread is initialized.
 #[inline]
 pub unsafe fn init_local_ctx(ctx: &GlobalCtx) -> *mut LocalCtx {
@@ -25,6 +28,9 @@ pub unsafe fn init_local_ctx(ctx: &GlobalCtx) -> *mut LocalCtx {
 }
 
 /// Deinitializes the local context object.
+///
+/// # Safety
+///
 /// This function must only be called once: when a thread is terminating.
 /// It is marked as `unsafe`, since multiple other API functions rely
 /// on the assumption that the current thread remains initialized.
@@ -33,10 +39,14 @@ pub unsafe fn deinit_local_ctx() {
     drop(ptr::replace(LOCAL_CTX.get(), MaybeUninit::uninit()).assume_init());
 }
 
-/// Accessing the local context is unsafe, since the user needs to ensure that
-/// the context is initialized.
+/// # Safety
+/// The user needs to ensure that the context is initialized.
 #[inline]
 pub unsafe fn local_ctx() -> *mut LocalCtx {
     let ctx: *mut MaybeUninit<LocalCtx> = LOCAL_CTX.get();
     mem::transmute(ctx)
+}
+
+impl Drop for LocalCtx {
+    fn drop(&mut self) {}
 }

--- a/src/tools/bsan/bsan-rt/src/shadow.rs
+++ b/src/tools/bsan/bsan-rt/src/shadow.rs
@@ -14,7 +14,6 @@ use crate::Provenance;
 /// Most, if not all 64 bit architectures use 48-bits. However, the
 /// Armv8-A spec allows addressing 52 or 56 bits as well. No processors
 /// implement this yet, though, so we can use target_pointer_width.
-
 #[cfg(target_pointer_width = "64")]
 static VA_BITS: u32 = 48;
 


### PR DESCRIPTION
Adds a Clippy to the `fmt` step in CI. Unlike `rustfmt`, Clippy requires a build of the Rust compiler. Since we have modified the backend, we can't use the CI copy of LLVM to speed up this process, so instead, we use the version of Clippy for the latest nightly toolchain that we're based on.